### PR TITLE
Remove legacy pomo database path override

### DIFF
--- a/core/home/.local/bin/pomo
+++ b/core/home/.local/bin/pomo
@@ -22,10 +22,8 @@ from typing import Callable, NoReturn, TextIO, cast
 VERSION = "0.1.0"
 
 DB_PATH_ENV = "POMO_DB_PATH"
-LEGACY_DB_PATH_ENV = "TD_DB_PATH"
 DB_PATH = Path(
     os.environ.get(DB_PATH_ENV)
-    or os.environ.get(LEGACY_DB_PATH_ENV)
     or Path.home() / ".local" / "share" / "pomo" / "pomo.db"
 )
 
@@ -50,7 +48,6 @@ Other flags:
 
 Environment:
   POMO_DB_PATH             Override database path
-  TD_DB_PATH               Legacy database path override, used if POMO_DB_PATH is unset
 """
 
 LIST_HELP = """Usage:


### PR DESCRIPTION
## Summary

- remove support for the legacy `TD_DB_PATH` environment variable
- keep `POMO_DB_PATH` as the only database path override
- update the command help text accordingly

## Impact

The pomo script now uses `POMO_DB_PATH` or its default local data path. Existing users relying on `TD_DB_PATH` must switch to `POMO_DB_PATH`.

## Validation

- `pre-commit run --all-files`
- `make test-core`