### PR TITLE
[codex] there must be a better way

### DIFF
--- a/core/home/.profile
+++ b/core/home/.profile
@@ -4,9 +4,7 @@
 # see /usr/share/doc/bash/examples/startup-files for examples.
 # the files are located in the bash-doc package.
 
-# the default umask is set in /etc/profile; for setting the umask
-# for ssh logins, install and configure the libpam-umask package.
-#umask 022
+umask 022
 
 # if running bash
 if [ -n "$BASH_VERSION" ]; then

--- a/desktop/home/.config/sway/config
+++ b/desktop/home/.config/sway/config
@@ -81,7 +81,7 @@ floating_modifier $mod
 # ____________________________________________________________________________
 
 # Start a terminal
-bindsym $mod+Return exec wezterm start -- bash -c 'command -v fastfetch >/dev/null 2>&1 && fastfetch; exec zsh'
+bindsym $mod+Return exec wezterm start -- bash -c 'command -v cowsay >/dev/null 2>&1 && cowsay -f dragon "There must be a better way!"; exec zsh'
 
 # kill focused window
 bindsym $mod+c kill


### PR DESCRIPTION
## Summary

- set an explicit `umask 022` for login shells
- replace the optional `fastfetch` terminal greeting with a dragon rendered by `cowsay`
- keep terminal startup working when `cowsay` is unavailable

## Impact

New Sway terminals show the message “There must be a better way!” when `cowsay` and its dragon cowfile are installed. Otherwise, startup proceeds directly to Zsh.

## Validation

- `prek run --all-files`
- `sway --validate -c desktop/home/.config/sway/config`
- core/desktop Docker builds were canceled because they rebuild unrelated Rust packages for these configuration-only changes